### PR TITLE
Attach services directly to host network.

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ import redis
 from flask import Flask
 
 app = Flask(__name__)
-cache = redis.Redis(host='redis', port=6379)
+cache = redis.Redis(host='localhost', port=6379)
 
 def get_hit_count():
     retries = 5

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 services:
   web:
     build: .
-    ports:
-      - "8000:5000"
+    network_mode: "host"
   redis:
     image: "redis:alpine"
+    network_mode: "host"


### PR DESCRIPTION
Attach services directly to host network, demonstrating workaround for Internet connectivity from the app within an MDE.